### PR TITLE
Alias `JWT` for `JsonWebToken` can be turned off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### v0.3.4 (2017-0x-xx)
+
+* Enhancements
+  * Alias `JWT` for `JsonWebToken` can be turned off with `RUBY_GEM_JSON_WEB_TOKEN_SKIP_ALIAS` environment variable.
+
 ### v0.3.3 (2017-01-16)
 
 * Bug fixes

--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -33,4 +33,4 @@ module JsonWebToken
 end
 
 # alias
-JWT = JsonWebToken
+JWT = JsonWebToken unless ENV['RUBY_GEM_JSON_WEB_TOKEN_SKIP_ALIAS']


### PR DESCRIPTION
Thank you for your great library!

We are using this gem in a large project, where a different lib brings in a dependency to the [jwt](https://github.com/jwt/ruby-jwt) gem. The alias breaks the usage of the other gem. With this PR, the alias can be turned off through an environment variable.